### PR TITLE
Remoção do required no input "Senha de Professor"

### DIFF
--- a/sgea/login/templates/usuarios/home.html
+++ b/sgea/login/templates/usuarios/home.html
@@ -57,7 +57,7 @@
 
                     <div class="form-cadastroUsu-grupo" id="campoSenhaProfessor" style="display:none;">
                         <label for="senha_professor">Senha de professor</label>
-                        <input type="password" name="senha_professor" id="senha_professor" required>
+                        <input type="password" name="senha_professor" id="senha_professor">
                     </div>
                   </div>
 


### PR DESCRIPTION
- O atributo "required" do campo de senha do professor, na tela de cadastro de usuários, estava causando conflito no envio, então foi removido